### PR TITLE
Fixed color readability on explorer issue

### DIFF
--- a/src/gui/src/css/style.css
+++ b/src/gui/src/css/style.css
@@ -112,6 +112,14 @@ pre {
     --select-saturation: 74.22%;
     --select-lightness: 55.88%;
     --select-color: hsl(var(--select-hue), var(--select-saturation), var(--select-lightness));
+
+    /* Dynamic foreground for sidebar titles: prefers the color (white or black)
+       that has best contrast against the computed sidebar background. Falls
+       back to the original grey when `color-contrast()` isn't supported. */
+    --window-sidebar-title-color: color-contrast(
+        hsla(var(--window-sidebar-hue), var(--window-sidebar-saturation), var(--window-sidebar-lightness), var(--window-sidebar-alpha))
+        vs rgb(255 255 255), rgb(0 0 0)
+    );
 }
 
 html, body {
@@ -465,7 +473,7 @@ span.header-sort-icon img {
     line-height: 25px;
     margin-left: 15px;
     color: #555c61;
-    display: inline-block;
+    display: inline-block;  
 }
 
 .explore-table-headers-th-active {
@@ -1218,8 +1226,12 @@ span.header-sort-icon img {
     margin: 0;
     font-weight: bold;
     font-size: 13px;
-    color: #8f96a3;
-    text-shadow: 1px 1px rgb(247 247 247 / 15%);
+     /* Use a dynamic foreground color determined by contrast; keep the
+         original grey as a fallback for older browsers. */
+     color: var(--window-sidebar-title-color, #8f96a3);
+     /* Stronger multi-layer text-shadow gives a subtle outline making the
+         text readable on both light and dark sidebar backgrounds. */
+     text-shadow: 0 1px 0 rgba(255,255,255,0.22), 0 0 6px rgba(0,0,0,0.32);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     padding-left: 6px;
@@ -1234,7 +1246,9 @@ span.header-sort-icon img {
 }
 
 .window-sidebar-item:hover, .window-sidebar-item.has-open-contextmenu {
-    background-color: rgba(243, 243, 243, 0.8);
+    /* Hover background adapts to theme via --window-sidebar-hover-bg. Fallback
+       matches previous light hover used before theming. */
+    background-color: var(--window-sidebar-hover-bg, rgba(243, 243, 243, 0.8));
     cursor: pointer;
 }
 
@@ -1243,7 +1257,8 @@ span.header-sort-icon img {
     margin-top: 2px;
     padding: 4px;
     border-radius: 3px;
-    color: #444444;
+    /* Use contrast-aware color so text adapts to sidebar background. */
+    color: var(--window-sidebar-title-color, #8f96a3);
     font-size: 13px;
     cursor: pointer;
     transition: 0.15s background-color;
@@ -1255,7 +1270,13 @@ span.header-sort-icon img {
 }
 
 .window-sidebar-item-active, .window-sidebar-item-drag-active, .window-sidebar-item-active:hover {
-    background-color: #fefeff;
+    /* Active background should contrast with the title color. Modern
+       browsers will use the color-contrast() produced variable; fallback
+       to the previous light background for older browsers. */
+    background-color: var(--window-sidebar-active-bg, #fefeff);
+    /* Active item's text should use the title color (the computed contrast
+       foreground) so it remains readable against the active background. */
+    color: var(--window-sidebar-title-color, #8f96a3) !important;
 }
 
 .window-sidebar-item-placeholder {
@@ -1276,13 +1297,15 @@ span.header-sort-icon img {
 }
 
 .window-sidebar-item-dragging {
-    background-color: #f5f5f5 !important;
+    /* Drag background adapts to theme via `--window-sidebar-drag-bg`. */
+    background-color: var(--window-sidebar-drag-bg, #f5f5f5) !important;
     opacity: 0.8;
     cursor: grabbing;
 }
 
 .ui-sortable-helper {
-    background: white !important;
+    /* Sortable helper background should also adapt slightly. */
+    background: var(--window-sidebar-drag-helper-bg, white) !important;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1) !important;
 }
 
@@ -2865,6 +2888,7 @@ fieldset[name=number-code] {
     text-align: center;
     border-radius: 0.5rem;
     -moz-appearance: textfield;
+    appearance: textfield;
     border: 2px solid #9b9b9b;
     color: #485660;
 }
@@ -3238,7 +3262,7 @@ fieldset[name=number-code] {
     opacity: 1;
 }
 
-.launch-app-selected {}
+
 
 
 .website-badge-popover-title {

--- a/src/gui/src/helpers/color_contrast.js
+++ b/src/gui/src/helpers/color_contrast.js
@@ -1,0 +1,119 @@
+// Small color contrast helper
+// Exports getReadableTextColor(backgroundColor) -> 'black' or 'white'
+// Supports hex (#rgb, #rrggbb), rgb(), rgba(), hsl(), hsla()
+
+function clamp01(v){ return Math.max(0, Math.min(1, v)); }
+
+function srgbToLinear(c){
+    c = c / 255;
+    return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+}
+
+function relativeLuminance({r,g,b}){
+    // r,g,b in 0..255
+    const R = srgbToLinear(r);
+    const G = srgbToLinear(g);
+    const B = srgbToLinear(b);
+    return 0.2126 * R + 0.7152 * G + 0.0722 * B;
+}
+
+function contrastRatio(l1, l2){
+    const L1 = Math.max(l1, l2);
+    const L2 = Math.min(l1, l2);
+    return (L1 + 0.05) / (L2 + 0.05);
+}
+
+function parseHex(hex){
+    hex = hex.replace('#','');
+    if(hex.length === 3){
+        hex = hex.split('').map(c => c + c).join('');
+    }
+    if(hex.length !== 6) return null;
+    const r = parseInt(hex.substring(0,2),16);
+    const g = parseInt(hex.substring(2,4),16);
+    const b = parseInt(hex.substring(4,6),16);
+    return {r,g,b};
+}
+
+function parseRgb(input){
+    // rgb(a)?(r,g,b[,a])
+    const m = input.match(/rgba?\(([^)]+)\)/i);
+    if(!m) return null;
+    const parts = m[1].split(',').map(s=>s.trim());
+    if(parts.length < 3) return null;
+    const parseComp = (s, idx) => {
+        if(s.endsWith('%')){
+            return Math.round(parseFloat(s) * 2.55);
+        }
+        return Math.round(parseFloat(s));
+    }
+    const r = parseComp(parts[0],0);
+    const g = parseComp(parts[1],1);
+    const b = parseComp(parts[2],2);
+    return {r: clamp01(r/255)*255, g: clamp01(g/255)*255, b: clamp01(b/255)*255};
+}
+
+function hslToRgb(h,s,l){
+    h = h % 360;
+    if(h < 0) h += 360;
+    s = clamp01(s/100);
+    l = clamp01(l/100);
+    if(s === 0){
+        const v = Math.round(l * 255);
+        return {r:v,g:v,b:v};
+    }
+    const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+    const p = 2 * l - q;
+    const hk = h / 360;
+    const t = (n) => {
+        let tc = hk + n;
+        if(tc < 0) tc += 1;
+        if(tc > 1) tc -= 1;
+        if(tc < 1/6) return p + (q - p) * 6 * tc;
+        if(tc < 1/2) return q;
+        if(tc < 2/3) return p + (q - p) * (2/3 - tc) * 6;
+        return p;
+    }
+    const r = Math.round(t(1/3) * 255);
+    const g = Math.round(t(0) * 255);
+    const b = Math.round(t(-1/3) * 255);
+    return {r,g,b};
+}
+
+function parseHsl(input){
+    const m = input.match(/hsla?\(([^)]+)\)/i);
+    if(!m) return null;
+    const parts = m[1].split(',').map(s=>s.trim());
+    if(parts.length < 3) return null;
+    const h = parseFloat(parts[0]);
+    const s = parseFloat(parts[1].replace('%',''));
+    const l = parseFloat(parts[2].replace('%',''));
+    return hslToRgb(h,s,l);
+}
+
+function parseColor(input){
+    if(!input || typeof input !== 'string') return null;
+    input = input.trim();
+    if(input.startsWith('#')) return parseHex(input);
+    if(input.toLowerCase().startsWith('rgb')) return parseRgb(input);
+    if(input.toLowerCase().startsWith('hsl')) return parseHsl(input);
+    return null;
+}
+
+export function getReadableTextColor(background){
+    const px = parseColor(background);
+    if(!px) {
+        // fallback to black
+        return 'black';
+    }
+    const Lbg = relativeLuminance(px);
+    const Lwhite = relativeLuminance({r:255,g:255,b:255});
+    const Lblack = relativeLuminance({r:0,g:0,b:0});
+    const contrastWhite = contrastRatio(Lbg, Lwhite);
+    const contrastBlack = contrastRatio(Lbg, Lblack);
+    // prefer the higher contrast
+    return (contrastWhite >= contrastBlack) ? 'white' : 'black';
+}
+
+// default export
+export default { getReadableTextColor };

--- a/src/gui/src/initgui.js
+++ b/src/gui/src/initgui.js
@@ -49,6 +49,8 @@ import { IPCService } from './services/IPCService.js';
 import { ExecService } from './services/ExecService.js';
 import { DebugService } from './services/DebugService.js';
 import { privacy_aware_path } from './util/desktop.js';
+// runtime contrast fallback for sidebar titles (sets --window-sidebar-title-color)
+import './js/sidebar-contrast.js';
 
 const launch_services = async function (options) {
     // === Services Data Structures ===

--- a/src/gui/src/js/sidebar-contrast.js
+++ b/src/gui/src/js/sidebar-contrast.js
@@ -1,0 +1,91 @@
+// Computes contrast of an hsla color and sets CSS variable --window-sidebar-title-color
+// so browsers without color-contrast() get the same behavior.
+
+(function(){
+    // Parse hsla(...) or rgb/hex that the sidebar uses. We'll compute luminance.
+    function getComputedSidebarColor() {
+        const sidebar = document.querySelector('.window-sidebar');
+        if (!sidebar) return null;
+        const style = getComputedStyle(sidebar).backgroundColor;
+        return style; // e.g. 'rgba(23, 34, 45, 0.8)'
+    }
+
+    function rgbaToRgbComponents(rgba) {
+        // rgba or rgb
+        const m = rgba.match(/rgba?\(([^)]+)\)/);
+        if (!m) return null;
+        const parts = m[1].split(',').map(p=>p.trim());
+        const r = parseFloat(parts[0]);
+        const g = parseFloat(parts[1]);
+        const b = parseFloat(parts[2]);
+        // alpha may be present, but we ignore as background behind it matters less
+        return {r,g,b};
+    }
+
+    function relativeLuminance({r,g,b}){
+        // sRGB -> linear
+        const srgb = [r,g,b].map(v => v / 255);
+        const lin = srgb.map(c => (c <= 0.03928) ? (c/12.92) : Math.pow((c+0.055)/1.055, 2.4));
+        return 0.2126 * lin[0] + 0.7152 * lin[1] + 0.0722 * lin[2];
+    }
+
+    function pickForeground(bgRgb){
+        const L = relativeLuminance(bgRgb);
+        const whiteContrast = (Math.max(L, 1) + 0.05) / (Math.min(L, 1) + 0.05); // simplified
+        // simpler: if bg is dark (L < 0.5) pick white else dark
+        return L < 0.5 ? '#ffffff' : '#000000';
+    }
+
+    function invertHex(hex){
+        // invert #rrggbb
+        if(!hex || hex[0] !== '#') return hex;
+        const r = 255 - parseInt(hex.substr(1,2),16);
+        const g = 255 - parseInt(hex.substr(3,2),16);
+        const b = 255 - parseInt(hex.substr(5,2),16);
+        return `#${[r,g,b].map(v=>v.toString(16).padStart(2,'0')).join('')}`;
+    }
+
+    function setSidebarContrastVar() {
+        const bg = getComputedSidebarColor();
+        if (!bg) return;
+        const comps = rgbaToRgbComponents(bg);
+        if (!comps) return;
+        const titleFg = pickForeground(comps);
+        // item color should be opposite for visual hierarchy
+        const itemFg = (titleFg === '#ffffff') ? '#000000' : '#ffffff';
+    document.documentElement.style.setProperty('--window-sidebar-title-color', titleFg);
+    document.documentElement.style.setProperty('--window-sidebar-item-color', itemFg);
+    // Choose an active background that contrasts with the title color.
+    // If title is light, pick a darker active bg; otherwise pick a light bg.
+    const activeBg = (titleFg === '#ffffff') ? '#2b2b2b' : '#ffffff';
+    document.documentElement.style.setProperty('--window-sidebar-active-bg', activeBg);
+    // hover bg: light overlay when title is dark, darker overlay when title is light
+    const hoverBg = (titleFg === '#ffffff') ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)';
+    document.documentElement.style.setProperty('--window-sidebar-hover-bg', hoverBg);
+    // drag background: darker when title is light, lighter when title is dark
+    const dragBg = (titleFg === '#ffffff') ? 'rgba(0,0,0,0.14)' : 'rgba(255,255,255,0.92)';
+    const dragHelperBg = (titleFg === '#ffffff') ? 'rgba(0,0,0,0.12)' : 'rgba(255,255,255,1)';
+    document.documentElement.style.setProperty('--window-sidebar-drag-bg', dragBg);
+    document.documentElement.style.setProperty('--window-sidebar-drag-helper-bg', dragHelperBg);
+        // debug
+        if(window.__PUTER_DEBUG_SIDEBAR_CONTRAST)
+            console.info('sidebar-contrast:', {bg, titleFg, itemFg});
+    }
+
+    // Run on DOMContentLoaded and also observe mutations to update on dynamic theme changes
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', setSidebarContrastVar);
+    } else {
+        setSidebarContrastVar();
+    }
+
+    // Observe style changes on documentElement (CSS variable changes or theme changes)
+    const observer = new MutationObserver(function(mutations){
+        // debounce
+        clearTimeout(window.__sidebarContrastTimer);
+        window.__sidebarContrastTimer = setTimeout(setSidebarContrastVar, 80);
+    });
+
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['style', 'class'] });
+
+})();


### PR DESCRIPTION
**Problem** #5 
When adjusting the lightness level of screen themes, sidebar header texts in the explorer become unreadable due to poor contrast between text and background colors.

**Key Features:** 
- Made the sidebar title colors dynamic 
- Made the drag and active sidebar title background dynamic

**Before:**
<img width="1268" height="732" alt="image" src="https://github.com/user-attachments/assets/31979bed-4526-4d6d-9b8b-41e0fa8ab5d0" />

**After:**
<img width="1260" height="752" alt="image" src="https://github.com/user-attachments/assets/b2f1e4b1-5372-405f-9078-e7d74a565ba6" />

**Video:** https://www.youtube.com/watch?v=KD9DRQGYgsI
