### PR TITLE
Add multiple alert box types and customization options

### DIFF
--- a/src/gui/src/UI/UIAlert.js
+++ b/src/gui/src/UI/UIAlert.js
@@ -18,6 +18,7 @@
  */
 
 import UIWindow from './UIWindow.js'
+import normalizeButtons from '../helpers/normalizeButtons.js'
 
 function UIAlert(options){
     // set sensible defaults
@@ -34,17 +35,27 @@ function UIAlert(options){
     }
 
     return new Promise(async (resolve) => {
-        // provide an 'OK' button if no buttons are provided
-        if(!options.buttons || options.buttons.length === 0){
-            options.buttons = [
-                {label: i18n('ok'), value: true, type: 'primary'}
-            ]
+        // track if we've already resolved to avoid double-resolve
+        let _resolved = false;
+        const _doResolve = (v) => {
+            if(_resolved) return;
+            _resolved = true;
+            resolve(v);
         }
 
-        // set body icon
-        options.body_icon = options.body_icon ?? window.icons['warning-sign.svg'];
-        if(options.type === 'success')
-            options.body_icon = window.icons['c-check.svg'];
+        // normalize buttons (accept strings or objects); provides default OK
+        options.buttons = normalizeButtons(options.buttons);
+
+        // set body icon with precedence: explicit icon / body_icon -> type map -> default warning
+        const TYPE_ICON_MAP = {
+            success: window.icons['c-check.svg'],
+            warning: window.icons['warning-sign.svg'],
+            info: window.icons['reminder.svg'] ?? window.icons['warning-sign.svg'],
+            error: window.icons['shield.svg'] ?? window.icons['warning-sign.svg'],
+            question: window.icons['reminder.svg'] ?? window.icons['warning-sign.svg'],
+        };
+
+        options.body_icon = options.icon ?? options.body_icon ?? TYPE_ICON_MAP[options.type] ?? window.icons['warning-sign.svg'];
 
         let santized_message = html_encode(options.message);
 
@@ -56,25 +67,53 @@ function UIAlert(options){
         santized_message = santized_message.replace(/&lt;p&gt;/g, '<p>');
         santized_message = santized_message.replace(/&lt;\/p&gt;/g, '</p>');
 
+        // prepare type-specific CSS class and body styles
+        const typeClass = options.type ? `window-alert--${options.type}` : '';
+
+        const TYPE_BACKGROUND = {
+            success: 'rgba(232, 249, 236, 0.95)', // soft green
+            info: 'rgba(230, 242, 255, 0.95)', // soft blue
+            warning: 'rgba(255, 249, 230, 0.95)', // soft yellow
+            error: 'rgba(255, 235, 235, 0.95)', // soft red
+            question: 'rgba(245, 240, 255, 0.95)', // soft purple
+        };
+
+        const bodyBackground = TYPE_BACKGROUND[options.type] ?? 'rgba(231, 238, 245, .95)';
+
+        // build body container so we can optionally inject custom UI
         let h = '';
-        // icon
-        h += `<img class="window-alert-icon" src="${html_encode(options.body_icon)}">`;
-        // message
-        h += `<div class="window-alert-message">${santized_message}</div>`;
-        // buttons
-        if(options.buttons && options.buttons.length > 0){
-            h += `<div style="overflow:hidden; margin-top:20px;">`;
+        h += `<div class="window-alert-body-inner">`;
+    // icon + message container (stacked and centered by default)
+    h += `<div class="window-alert-main" style="display:flex; flex-direction:column; gap:12px; align-items:center; text-align:center;">`;
+    h += `<img class="window-alert-icon" src="${html_encode(options.body_icon)}" style="margin:6px 0;">`;
+    h += `<div class="window-alert-message" style="max-width:100%;">${santized_message}</div>`;
+    h += `</div>`;
+
+        // placeholder for custom UI (or default button area)
+        h += `<div class="window-alert-custom-body" style="margin-top:16px;"></div>`;
+
+        // buttons - render later into the custom-body if not hidden
+        if(!options.hide_buttons && options.buttons && options.buttons.length > 0){
+            let btns_html = `<div style="overflow:hidden; margin-top:20px; text-align:right;">`;
             for(let y=0; y<options.buttons.length; y++){
-                h += `<button class="button button-block button-${html_encode(options.buttons[y].type)} alert-resp-button" 
-                                data-label="${html_encode(options.buttons[y].label)}"
-                                data-value="${html_encode(options.buttons[y].value ?? options.buttons[y].label)}"
-                                ${options.buttons[y].type === 'primary' ? 'autofocus' : ''}
-                                >${html_encode(options.buttons[y].label)}</button>`;
+                btns_html += `<button class="button button-block button-${html_encode(options.buttons[y].type)} alert-resp-button" ` +
+                                `data-label="${html_encode(options.buttons[y].label)}" ` +
+                                `data-value="${html_encode(options.buttons[y].value ?? options.buttons[y].label)}" ` +
+                                `${options.buttons[y].type === 'primary' ? 'autofocus' : ''}` +
+                                `>${html_encode(options.buttons[y].label)}</button>`;
             }
-            h += `</div>`;
+            btns_html += `</div>`;
+            // place buttons_html as data so we can inject it during onAppend where customUI may run
+            options._buttons_html = btns_html;
         }
 
-        const el_window = await UIWindow({
+        h += `</div>`;
+
+        // preserve any user callbacks so we can call them from our wrappers
+        const _user_onAppend = options.onAppend;
+        const _user_on_close = options.on_close;
+
+    const el_window = await UIWindow({
             title: null,
             icon: null,
             uid: null,
@@ -90,35 +129,91 @@ function UIAlert(options){
             draggable_body: options.draggable_body ?? true,
             allow_context_menu: false,
             show_in_taskbar: false,
-            window_class: 'window-alert',
+            window_class: `window-alert ${typeClass}`,
             dominant: true,
             body_content: h,
             width: 350,
             parent_uuid: options.parent_uuid,
             ...options.window_options,
+            // our onAppend will inject custom UI / buttons and wire escape handling
+            onAppend: function(this_window){
+                const $w = $(this_window);
+                const $custom = $w.find('.window-alert-custom-body');
+
+                // inject customUI if provided
+                try{
+                    if(options.customUI !== undefined && options.customUI !== null){
+                        if(window.isString(options.customUI)){
+                            $custom.html(options.customUI);
+                        }else if(options.customUI instanceof HTMLElement){
+                            $custom.empty().append(options.customUI);
+                        }else if(typeof options.customUI === 'function'){
+                            // pass the container element for the function to populate
+                            options.customUI($custom.get(0));
+                        }else{
+                            // fallback, stringify
+                            $custom.html(String(options.customUI));
+                        }
+                    }
+                }catch(err){
+                    console.error('UIAlert: error rendering customUI', err);
+                }
+
+                // inject buttons if we prepared them and buttons are not hidden
+                if(!options.hide_buttons && options._buttons_html){
+                    $custom.append(options._buttons_html);
+                }
+
+                // focus primary button if present
+                setTimeout(function(){
+                    $w.find('.button-primary').focus();
+                }, 10);
+
+                // attach keyup handler for Escape -> close & resolve null
+                $(document).on('keyup.uialert', function(e){
+                    if(e.key === 'Escape'){
+                        try{ $(this_window).close(); }catch(_){}
+                    }
+                });
+
+                // wire button clicks
+                $w.find('.alert-resp-button').on('click.uialert', function(ev){
+                    ev.preventDefault(); ev.stopPropagation();
+                    const v = $(this).attr('data-value');
+                    _doResolve(v);
+                    // remove key handler before close
+                    $(document).off('keyup.uialert');
+                    try{ $(this_window).close(); }catch(_){}
+                    return false;
+                });
+
+                // call user-provided onAppend if present
+                if(_user_onAppend && typeof _user_onAppend === 'function'){
+                    try{ _user_onAppend(this_window); }catch(err){ console.error(err); }
+                }
+            },
+            // our on_close will resolve to null if the window was closed without selecting a button
+            on_close: function(){
+                // remove key handler
+                $(document).off('keyup.uialert');
+                // if not resolved yet, resolve with null
+                _doResolve(null);
+                // call user-provided on_close if present
+                if(_user_on_close && typeof _user_on_close === 'function'){
+                    try{ _user_on_close(); }catch(err){ console.error(err); }
+                }
+            },
             window_css:{
                 height: 'initial',
             },
             body_css: {
                 width: 'initial',
                 padding: '20px',
-                'background-color': 'rgba(231, 238, 245, .95)',
+                'background-color': bodyBackground,
                 'backdrop-filter': 'blur(3px)',
             }
         });
-        // focus to primary btn
-        $(el_window).find('.button-primary').focus();
-
-        // --------------------------------------------------------
-        // Button pressed
-        // --------------------------------------------------------
-        $(el_window).find('.alert-resp-button').on('click',  async function(event){
-            event.preventDefault(); 
-            event.stopPropagation();
-            resolve($(this).attr('data-value'));
-            $(el_window).close();
-            return false;
-        })
+        // all wiring (buttons, ESC, customUI) was handled in our onAppend / on_close wrappers
     })
 }
 

--- a/src/gui/src/helpers/normalizeButtons.js
+++ b/src/gui/src/helpers/normalizeButtons.js
@@ -1,0 +1,42 @@
+/**
+ * Normalize buttons input for UIAlert.
+ * Accepts undefined, array of strings, or array of objects and returns
+ * an array of objects: { label, value, type }
+ */
+export default function normalizeButtons (buttons) {
+    // If nothing provided, return default OK primary button
+    if (!buttons || (Array.isArray(buttons) && buttons.length === 0)) {
+        return [{ label: i18n('ok'), value: true, type: 'primary' }];
+    }
+
+    // If caller passed a non-array, try to coerce to array
+    if (!Array.isArray(buttons)) {
+        buttons = [buttons];
+    }
+
+    const normalized = buttons.map((b) => {
+        if (typeof b === 'string') {
+            return { label: b, value: b, type: 'default' };
+        }
+        if (typeof b === 'object' && b !== null) {
+            const label = b.label ?? (b.value !== undefined ? String(b.value) : '');
+            const value = b.value !== undefined ? b.value : b.label;
+            const type = b.type ?? 'default';
+            return { label, value, type };
+        }
+        // fallback for unexpected types
+        return { label: String(b), value: b, type: 'default' };
+    }).filter(x => x && x.label !== undefined);
+
+    // ensure at least one primary button
+    if (!normalized.some(b => b.type === 'primary')) {
+        normalized[0].type = normalized[0].type || 'primary';
+    }
+
+    // final safety: if nothing returned, fallback to OK primary
+    if (!normalized || normalized.length === 0) {
+        return [{ label: i18n('ok'), value: true, type: 'primary' }];
+    }
+
+    return normalized;
+}


### PR DESCRIPTION
**Problem** #4
Currently, alert boxes only display warning-type dialogs. The system needs support for different alert types (info, success, error, question) with appropriate icons and styling, plus the ability to create custom popups with configurable buttons.

**Key Features:**
- Develop different warning types
- Ability to create your own custom popups

**Before**
<img width="2940" height="1912" alt="image" src="https://github.com/user-attachments/assets/a344a65d-74da-43b2-aba2-40e2f7374ae9" />

**After**
<img width="2940" height="1912" alt="image" src="https://github.com/user-attachments/assets/5f5be4dc-5ade-48d8-a98f-a3f41cda2ba4" />

**Video:** https://www.youtube.com/watch?v=KXa7-dt45bQ&feature=youtu.be