### PR TITLE
Feature: added option to hide or show desktop icons

### DIFF
--- a/src/gui/src/UI/UIDesktop.js
+++ b/src/gui/src/UI/UIDesktop.js
@@ -708,6 +708,8 @@ async function UIDesktop(options){
     // update local user preferences
     const user_preferences = {
         show_hidden_files: JSON.parse(await puter.kv.get('user_preferences.show_hidden_files')),
+        // whether desktop icons should be visible. Default to true when unset.
+        show_desktop_icons: (await puter.kv.get('user_preferences.show_desktop_icons')) === null ? true : JSON.parse(await puter.kv.get('user_preferences.show_desktop_icons')),
         language: await puter.kv.get('user_preferences.language'),
         clock_visible: await puter.kv.get('user_preferences.clock_visible'),
     };
@@ -719,6 +721,12 @@ async function UIDesktop(options){
         }
 
         window.update_user_preferences(user_preferences);
+        // Apply desktop icons visibility preference immediately
+        try{
+            window.toggle_desktop_icons(window.user_preferences.show_desktop_icons);
+        }catch(e){
+            // ignore if toggle function not available yet
+        }
     });
 
     // Append to <body>
@@ -941,6 +949,16 @@ async function UIDesktop(options){
                                 show_hidden_files : !window.user_preferences.show_hidden_files,
                             });
                             window.show_or_hide_files(document.querySelectorAll('.item-container'));
+                        }
+                    },
+                    // -------------------------------------------
+                    // Show/Hide Desktop Icons
+                    // -------------------------------------------
+                    {
+                        html: window.user_preferences.show_desktop_icons ? 'Hide Desktop Icons' : 'Show Desktop Icons',
+                        onClick: function(){
+                            // toggle via helper which persists preference
+                            window.toggle_desktop_icons(!window.user_preferences.show_desktop_icons);
                         }
                     },
                     // -------------------------------------------

--- a/src/gui/src/css/style.css
+++ b/src/gui/src/css/style.css
@@ -1765,6 +1765,18 @@ label {
     font-weight: 500;
 }
 
+/* Hide desktop icons when the desktop has the class .desktop-icons-hidden */
+.desktop.item-container.desktop-icons-hidden > .item,
+.desktop.item-container.desktop-icons-hidden .item {
+    display: none !important;
+}
+
+/* When icons are hidden, also hide selected/cloned helpers to avoid visual artifacts */
+.desktop.item-container.desktop-icons-hidden .item-selected,
+.desktop.item-container.desktop-icons-hidden .item-selected-clone {
+    display: none !important;
+}
+
 .device-phone .toolbar {
     z-index: 1;
 }

--- a/src/gui/src/helpers.js
+++ b/src/gui/src/helpers.js
@@ -2498,6 +2498,36 @@ window.save_desktop_item_positions = ()=>{
     puter.kv.set('desktop_item_positions', window.desktop_item_positions);
 }
 
+/**
+ * Toggle visibility of desktop icons. Stores preference when called with explicit value.
+ * @param {boolean} [show] - If provided, set visibility to this value and persist to user preferences.
+ */
+window.toggle_desktop_icons = function(show){
+    const el_desktop = document.querySelector('.desktop');
+    // if desktop not present, nothing to do
+    if(!el_desktop) return;
+
+    // If show is undefined, just toggle
+    if(typeof show === 'undefined')
+        show = !window.user_preferences?.show_desktop_icons;
+
+    if(show){
+        $(el_desktop).removeClass('desktop-icons-hidden');
+        // reapply saved positions (if any)
+        window.set_desktop_item_positions(el_desktop);
+    }
+    else{
+        $(el_desktop).addClass('desktop-icons-hidden');
+    }
+
+    // persist preference
+    try{
+        window.mutate_user_preferences({ show_desktop_icons: show });
+    }catch(e){
+        // ignore
+    }
+}
+
 window.delete_desktop_item_positions = ()=>{
     window.desktop_item_positions = {}
     puter.kv.del('desktop_item_positions');


### PR DESCRIPTION
**Problem** #3 
Add the ability to hide or show all desktop icons through the right-click context menu, similar to functionality found in modern desktop operating systems (Windows, macOS, Linux).

**Key Features**
- Right-click on empty desktop area
- Select "Hide Desktop Icons" or "Show Desktop Icons" from context menu
- Toggle visibility state that persists across sessions
- Access files normally through other means (file explorer, search) while icons are hidden

**Before**
<img width="2940" height="1680" alt="image" src="https://github.com/user-attachments/assets/64a6b20e-4593-4185-8afb-b7ab25ed14d8" />

**After**
<img width="2938" height="1676" alt="image" src="https://github.com/user-attachments/assets/376dcca5-13dd-4a23-b5b0-eb098134dfd8" />


**Video:** https://www.youtube.com/watch?v=Tf-ibaNWd2A
