### PR TITLE
Bug: fixed throw 403 error when creating dir in root dir

### DIFF
--- a/src/backend/src/filesystem/hl_operations/hl_mkdir.js
+++ b/src/backend/src/filesystem/hl_operations/hl_mkdir.js
@@ -278,6 +278,12 @@ class HLMkdir extends HLFilesystemOperation {
             : await this._get_existing_top_parent({ top_parent: parent_node })
             ;
 
+        if (top_parent.isRoot) {
+            throw APIError.create('forbidden', null, {
+                message: 'Cannot create directories in root folder'
+            });
+        }
+
         // `parent_node` becomes the parent of the last directory name
         // specified under `path`.
         parent_node = await this._create_parents({


### PR DESCRIPTION
**Problem** #9 
When users attempt to create directories in the root directory of the filesystem, the system currently returns a 500 Internal Server Error. This is problematic because a 500 status code indicates an unexpected server failure, when in reality this is an intentional restriction - the root directory is read-only by design.

**Key Features**
- Creating a directory in the root directory now throws a 403 Forbidden Error instead of a 500 Internal Server Error
- Creating a directory in a valid location still works as normal. 

**Before:**
<img width="2940" height="1682" alt="image" src="https://github.com/user-attachments/assets/4e256c72-c53e-4d78-8089-4e726da885ad" />

**After:**
<img width="2940" height="1680" alt="image" src="https://github.com/user-attachments/assets/ee7d4a14-9980-4523-958c-581b3ca1032f" />

**Video:** https://www.youtube.com/watch?v=NwCkd1VDsOE