### PR TITLE
feature/set_desktop_bg

### DIFF
--- a/src/gui/src/UI/UIItem.js
+++ b/src/gui/src/UI/UIItem.js
@@ -1184,6 +1184,56 @@ function UIItem(options){
                 });                
             }
             // -------------------------------------------
+            // Set As Desktop Background (images only)
+            // -------------------------------------------
+            // Only show for non-directory, non-trashed, non-trash-path items that are images
+            if(!is_trash && !is_trashed && !options.is_dir){
+                const mime = $(el_item).attr('data-type') || options.type || '';
+                const ext = path.extname($(el_item).attr('data-path')).toLowerCase();
+                const image_exts = ['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.svg'];
+                const is_image = mime.startsWith('image/') || image_exts.includes(ext);
+                if(is_image){
+                    menu_items.push({
+                        html: i18n('change_desktop_background'),
+                        onClick: async function(){
+                            try{
+                                // Sign the file to obtain a read URL
+                                const uid = $(el_item).attr('data-uid');
+                                const sig = await puter.fs.sign(window.host_app_uid ?? null, { uid: uid, action: 'write' });
+                                let item_sig = sig?.items ?? sig;
+                                if(Array.isArray(item_sig)) item_sig = item_sig[0];
+                                const readURL = item_sig?.read_url ?? item_sig?.readURL ?? undefined;
+
+                                if(!readURL){
+                                    console.error('Failed to obtain file read URL for wallpaper');
+                                    return;
+                                }
+
+                                // Persist preference to server
+                                try{
+                                    await $.ajax({
+                                        url: window.api_origin + "/set-desktop-bg",
+                                        type: 'POST',
+                                        data: JSON.stringify({ url: readURL, fit: 'cover' }),
+                                        async: true,
+                                        contentType: "application/json",
+                                        headers: { "Authorization": "Bearer "+window.auth_token },
+                                    });
+                                }catch(err){
+                                    console.warn('Persisting desktop background preference failed', err);
+                                }
+
+                                // Apply wallpaper immediately
+                                window.set_desktop_background({ url: readURL, fit: 'cover' });
+                            }
+                            catch(err){
+                                console.error(err);
+                            }
+                        }
+                    })
+                }
+            }
+            // -------------------------------------------
             // Zip
             // -------------------------------------------
             if(!is_trash && !is_trashed && !$(el_item).attr('data-path').endsWith('.zip')){


### PR DESCRIPTION
**Problem** #10 
Users currently have no quick way to set an image as their desktop background directly from the file system. They must navigate through settings or other indirect methods to change their wallpaper. Adding a context menu option when right-clicking on image files would provide a convenient, intuitive way for users to personalize their desktop environment.

This feature enhances the user experience by reducing friction in a common personalization task. It follows familiar desktop environment patterns where users expect to be able to right-click images and set them as backgrounds, making the interface more intuitive and user-friendly.

**Key Features**
- Right-click and can set the background with a specific image

**Before:**
<img width="2940" height="1680" alt="image" src="https://github.com/user-attachments/assets/f64c6bcf-8470-4a08-aa4a-e18055c5a49f" />

**After**
<img width="2940" height="1678" alt="image" src="https://github.com/user-attachments/assets/7be21ac8-8c00-48ec-903b-f4aff8ffa98d" />

**Video:** https://youtu.be/oVk5JJCrm-I